### PR TITLE
動画教材のCSVインポート機能を実装 

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,3 +8,6 @@ end
 
 Text.destroy_all
 ImportCsv.text_import("db/csv_data/text_data.csv")
+
+Movie.destroy_all
+ImportCsv.movie_import("db/csv_data/movie_data.csv")

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -11,4 +11,15 @@ class ImportCsv
     end
     puts "テキスト教材のCSVデータ投入に成功しました。"
   end
+
+  def self.movie_import(path)
+    CSV.foreach(path, headers: true) do |row|
+      Movie.create!(
+        genre: row["genre"],
+        title: row["title"],
+        url: row["url"]
+      )
+    end
+    puts "動画教材のCSVデータ投入に成功しました。"
+ end
 end


### PR DESCRIPTION
## 10

close #10

## 実装内容

- `lib/autoloads/import_csv.rb`に動画教材のCSV（`db/csv_data/movie_data.csv`）を読み込み、movies テーブルにデータを投入する処理を追加
- `db/seeds.rb`に上記の処理を呼び出す記述を追加
  - `Movie.destroy_all` を入れ、実行時にデータを初期化

## 参考資料

- CSVインポート
  - [やんばるCODE教材（CSVインポート）](https://www.yanbaru-code.com/texts/217)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認