### PR TITLE
11.ナビバーの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,7 +6,7 @@
 /* 全体 */
 
 .base-container {
-  margin: 0 auto;
+  margin: 7% auto 0;
   padding: 1rem
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,9 @@
 }
 
 @import "bootstrap/scss/bootstrap";
+
+/* header部分 */
+.header-nav {
+    font-size: 0.8rem;
+    margin: 0 auto;
+  }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,41 @@
+<nav class="navbar navbar-expand-md mw-lg bg-primary navbar-dark header-nav ">
+  <a class="navbar-brand" href="#">やんばるエキスパート</a>
+  <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarNav">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNav">
+    <div class="navbar-nav">
+      <div class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown">Rails</a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="#">Ruby/Rails教材</a>
+          <a class="dropdown-item" href="#">動画教材</a>
+          <a class="dropdown-item" href="#">AWS講座</a>
+        </div>
+      </div>
+      <div class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown">PHP</a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="#">PHPテキスト教材</a>
+          <a class="dropdown-item" href="#">PHP動画教材</a>
+        </div>
+      </div>
+      <a class="nav-item nav-link" href="#">LINE</a>
+      <%# ログイン時 %>
+      <% if user_signed_in? %>
+      <div class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown">マイページ</a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="#">進捗管理</a>
+          <a class="dropdown-item" href="#">アカウント編集</a>
+          <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class:"dropdown-item", data: { confirm: "ログアウトしますか？" } %>
+        </div>
+      </div>
+      <%# ログアウト時 %>
+      <% else %>
+      <%= link_to "新規登録", new_user_registration_path,class:"nav-item nav-link" %>
+      <%= link_to "ログイン", new_user_session_path,class:"nav-item nav-link" %>
+      <% end %>
+    </div>
+  </div>
+</nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -27,7 +27,7 @@
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown">マイページ</a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
           <a class="dropdown-item" href="#">進捗管理</a>
-          <a class="dropdown-item" href="#">アカウント編集</a>
+          <%= link_to "アカウント編集", edit_user_registration_path, class:"dropdown-item" %>
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class:"dropdown-item", data: { confirm: "ログアウトしますか？" } %>
         </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-  <header class="fixed-top base-bg-color">
+  <header class="fixed-top bg-primary">
     <%= render 'layouts/header'%>
   </header>
   <main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,12 +13,7 @@
 
   <body>
     <header>
-      <% if user_signed_in? %>
-        <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
-      <% else %>
-        <%= link_to "ログイン", new_user_session_path %>
-        <%= link_to "新規登録", new_user_registration_path %>
-      <% end %>
+      <%= render 'layouts/header'%>
     </header>
     <main>
       <%# max_width メソッドはapplication_helper.rbに記載 %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,27 +1,29 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>チーム開発 やんばるCODE教材クローン</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-  </head>
+<head>
+  <title>チーム開発 やんばるCODE教材クローン</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  <body>
-    <header>
-      <%= render 'layouts/header'%>
-    </header>
-    <main>
-      <%# max_width メソッドはapplication_helper.rbに記載 %>
-      <div class="base-container <%= max_width %>">
-        <%= yield %>
-      </div>
-    </main>
-    <footer>
-    </footer>
-  </body>
+  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+</head>
+
+<body>
+  <header>
+    <%= render 'layouts/header'%>
+  </header>
+  <main>
+    <%# max_width メソッドはapplication_helper.rbに記載 %>
+    <div class="base-container <%= max_width %>">
+      <%= yield %>
+    </div>
+  </main>
+  <footer>
+  </footer>
+</body>
+
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-  <header>
+  <header class="fixed-top base-bg-color">
     <%= render 'layouts/header'%>
   </header>
   <main>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.2.1",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^4.5.1",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,7 +1489,7 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^4.6.0:
+bootstrap@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"
   integrity sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==


### PR DESCRIPTION
close issue #11

## 実装内容
- Bootstrapを使い，教材アプリに近いナビバーを作成
　- 部分テンプレート app/views/layouts/_header.html.erb を作成
　- 「新規登録」「ログイン」「ログアウト」のリンク有(他は href 属性を #にしている)
　- ナビバーは fixed-top クラスを利用(headerクラスに付与)
　- ナビバーに隠れないようなスタイルの調整(base-container クラスにmargin7%)

## 参考資料

- Bootstrap部分
  - [やんばるCODEアプリ](https://www.yanbaru-code.com/texts/216)

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考
- コンフリクトが起きた為、解消の作業をしております。
- ナビバーの文字の位置に関しては、下の画面に合わせて調整したい為、後でfixのissueを立てます。
- Bootstrapのバージョンを安定版に変更。(元のバージョンだとドロップダウンが作動しない為)