### PR TITLE
17.動画教材一覧ページを実装

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,5 @@
+class MoviesController < ApplicationController
+  def index
+    @movies = Movie.all
+  end
+end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.all
+    @movies = Movie.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"])
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,5 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"])
+    @movies = Movie.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]).order(id: :asc)
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,7 +9,7 @@
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown">Rails</a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
           <a class="dropdown-item" href="#">Ruby/Rails教材</a>
-          <a class="dropdown-item" href="#">動画教材</a>
+          <a class="dropdown-item" href="/movies">動画教材</a>
           <a class="dropdown-item" href="#">AWS講座</a>
         </div>
       </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,20 @@
-<% @movies.each do |movie| %>
-<%= movie.title %>
-<%= movie.genre %>
-<% end %>
+
+<div class="container mt-5">
+  <div class="row">
+  <% @movies.each.with_index(1) do |movie, i| %>
+    <div class="col-12 col-md-6 col-lg-4 mb-4">
+      <div class="card border-dark " style="height: 25rem;">
+        <iframe src=<%= movie.url %> frameborder="0" height="50%"></iframe>
+          <div class="card-body">
+            <a href="#" class="btn btn-secondary btn-block">視聴済みにする</a>
+            <p class="card-title pt-4">Lv.<%= i %> : <%= movie.title %></p>
+          </div>
+      </div>
+    </div>
+  <% end %>
+  </div>
+</div> 
+
+
+
+

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -4,7 +4,7 @@
   <% @movies.each.with_index(1) do |movie, i| %>
     <div class="col-12 col-md-6 col-lg-4 mb-3">
       <div class="card border-dark " style="height: 23rem;">
-        <iframe src=<%= movie.url %> frameborder="0" height="50%"></iframe>
+        <iframe height="50%" src=<%= movie.url %> frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
           <div class="card-body">
             <a href="#" class="btn btn-secondary btn-block">視聴済みにする</a>
             <p class="card-title pt-4">Lv.<%= i %> : <%= movie.title %></p>
@@ -14,7 +14,3 @@
   <% end %>
   </div>
 </div> 
-
-
-
-

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,4 @@
+<% @movies.each do |movie| %>
+<%= movie.title %>
+<%= movie.genre %>
+<% end %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -2,8 +2,8 @@
 <div class="container mt-5">
   <div class="row">
   <% @movies.each.with_index(1) do |movie, i| %>
-    <div class="col-12 col-md-6 col-lg-4 mb-4">
-      <div class="card border-dark " style="height: 25rem;">
+    <div class="col-12 col-md-6 col-lg-4 mb-3">
+      <div class="card border-dark " style="height: 23rem;">
         <iframe src=<%= movie.url %> frameborder="0" height="50%"></iframe>
           <div class="card-body">
             <a href="#" class="btn btn-secondary btn-block">視聴済みにする</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root to: 'texts#index'
-  resources :movies
+  resources :movies, only: [:index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root to: 'texts#index'
+  resources :movies
 end


### PR DESCRIPTION
close #17 

## 実装内容

- Rails動画教材の一覧ページを作成
  - ナビバーの動画教材ページへのリンクが機能するようルーティングを設定
  - 動画用のコントローラーを作成　
    - Rails動画教材で表示するジャンルを["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]のみに設定
  - 動画教材のビューファイルのスタイルをBootstrapを用いて修正

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
