### PR TITLE
Railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,7 +47,7 @@ div.text-card-container {
   margin-bottom: 50px;
 }
 
-div.content-card {
+.content-card {
   height: 370px;
   max-width: 376px;
   margin: 0 auto;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,3 +37,17 @@
 .alert-alert {
   @extend .alert-danger;
 } 
+
+/* テキスト教材 一覧表示部分 */
+
+div.text-card-container {
+  padding-left: 9px;
+  padding-right: 9px;
+  margin-bottom: 50px;
+}
+
+div.content-card {
+  height: 370px;
+  max-width: 376px;
+  margin: 0 auto;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 .base-container {
   margin: 7% auto 0;
   padding: 1rem;
+  padding-top: 7%;
 }
 
 /* max-width */

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,5 +1,6 @@
 class TextsController < ApplicationController
   def index
-
+    genre_rails = ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]
+    @texts = Text.where(genre: genre_rails)
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
     genre_rails = ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]
-    @texts = Text.where(genre: genre_rails)
+    @texts = Text.where(genre: genre_rails).order("id")
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,7 +8,7 @@
       <div class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown">Rails</a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-          <%= link_to "Ruby/Railsテキスト教材", texts_path, class: "dropdown-item" %>
+          <a class="dropdown-item" href="/texts">Ruby/Railsテキスト教材</a>
           <a class="dropdown-item" href="#">動画教材</a>
           <a class="dropdown-item" href="#">AWS講座</a>
         </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,7 +8,7 @@
       <div class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown">Rails</a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-          <a class="dropdown-item" href="#">Ruby/Rails教材</a>
+          <%= link_to "Ruby/Railsテキスト教材", texts_path, class: "dropdown-item" %>
           <a class="dropdown-item" href="#">動画教材</a>
           <a class="dropdown-item" href="#">AWS講座</a>
         </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -5,16 +5,12 @@
   <div class="row">
     <% @texts.each do |text| %>
       <div class="col-12 col-md-6 col-lg-4 text-card-container">
-        <%= link_to text, class: "card", target: :_blank, rel: "noopener noreferrer" do %>
-          <div class="card content-card border-dark mb-3">
-            <div class="card-header p-0">
-              <img class="card-img-top" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
-            </div>
+        <%= link_to text, class: "card content-card border-dark mb-3", target: :_blank, rel: "noopener noreferrer" do %>
+            <img class="card-img-top" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
             <div class="card-body text-dark text-card-body">
               <p class="card-text text-title"><%= text.title %></p>
               <p>【<%= text.genre %>】</p>
             </div>
-          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -4,17 +4,19 @@
   </div>
   <div class="row">
     <% @texts.each do |text| %>
-    <div class="col-12 col-md-6 col-lg-4 text-card-container">
-      <div class="card content-card border-dark mb-3">
-        <div class="card-header p-0">
-          <img class="card-img-top" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
-        </div>
-        <div class="card-body text-dark text-card-body">
-          <p class="card-text text-title"><%= text.title %></p>
-          <p>【<%= text.genre %>】</p>
-        </div>
+      <div class="col-12 col-md-6 col-lg-4 text-card-container">
+        <%= link_to text, class: "card", target: :_blank, rel: "noopener noreferrer" do %>
+          <div class="card content-card border-dark mb-3">
+            <div class="card-header p-0">
+              <img class="card-img-top" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
+            </div>
+            <div class="card-body text-dark text-card-body">
+              <p class="card-text text-title"><%= text.title %></p>
+              <p>【<%= text.genre %>】</p>
+            </div>
+          </div>
+        <% end %>
       </div>
-    </div>
     <% end %>
   </div>
 </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,3 +1,6 @@
 <% @texts.each do |text| %>
-  <%= text.title %>
+  <div>
+    <p><%= text.title %></p>
+    <p>【<%= text.genre %>】</p>
+  </div>
 <% end %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,6 +1,20 @@
-<% @texts.each do |text| %>
-  <div>
-    <p><%= text.title %></p>
-    <p>【<%= text.genre %>】</p>
+<div class="texts-wrapper">
+  <div class="contents-title text-center">
+    <h1>Rails テキスト教材</h1>
   </div>
-<% end %>
+  <div class="row">
+    <% @texts.each do |text| %>
+    <div class="col-12 col-md-6 col-lg-4 text-card-container">
+      <div class="card content-card border-dark mb-3">
+        <div class="card-header p-0">
+          <img class="card-img-top" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
+        </div>
+        <div class="card-body text-dark text-card-body">
+          <p class="card-text text-title"><%= text.title %></p>
+          <p>【<%= text.genre %>】</p>
+        </div>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,1 +1,3 @@
-<button type="button" class="btn btn-primary">Primary</button>
+<% @texts.each do |text| %>
+  <%= text.title %>
+<% end %>


### PR DESCRIPTION
## 15

close #15

## 実装内容

- Railsテキスト教材の一覧ページを作成
  - textsコントローラの index を編集
    -  ジャンル["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]の教材を取得
  -  Bootstrapの Cards や Grid System のスタイルを適用
  - 画像部分はデフォルト画像を表示
  - 詳細ページへのリンクを追加
 - ナビバーのテキスト教材ページへのリンクが機能するようにする
　
※検索機能・読破済み機能も別タスクとする
※Take off Railsなどの広告は削ること

## 参考資料

- ログイン機能
  - [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
  - [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考

- `app/assets/stylesheets/application.scss`の全体ページのスタイルを一部変更しました。
