### PR TITLE
Railsテキスト教材一覧・詳細ページ「読破済み機能」の実装

### DIFF
--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -1,0 +1,11 @@
+class ReadsController < ApplicationController
+  def create
+    current_user.reads.create!(text_id: params[:text_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.reads.find_by(text_id: params[:text_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/reads_controller.rb
+++ b/app/controllers/reads_controller.rb
@@ -1,11 +1,11 @@
 class ReadsController < ApplicationController
   def create
-    current_user.reads.create!(text_id: params[:text_id])
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.reads.create!(text_id: @text.id)
   end
 
   def destroy
-    current_user.reads.find_by(text_id: params[:text_id]).destroy!
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.reads.find_by(text_id: @text.id).destroy!
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -2,6 +2,7 @@ class TextsController < ApplicationController
   def index
     genre_rails = ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]
     @texts = Text.where(genre: genre_rails).order("id")
+    @read_text_ids = current_user.reads.pluck(:text_id)
   end
 
   def show

--- a/app/models/read.rb
+++ b/app/models/read.rb
@@ -1,0 +1,4 @@
+class Read < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+end

--- a/app/models/read.rb
+++ b/app/models/read.rb
@@ -1,4 +1,9 @@
 class Read < ApplicationRecord
   belongs_to :user
   belongs_to :text
+
+  validates :user_id, uniqueness: {
+    scope: :text_id,
+    message: "は同じ教材に2回以上読破済みには設定できません"
+  }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -3,4 +3,8 @@ class Text < ApplicationRecord
   validates :genre, presence: true
   validates :title, presence: true
   validates :content, presence: true
+
+  def read_by?(user)
+    reads.find_by(user_id: user.id).present?
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,5 @@
 class Text < ApplicationRecord
+  has_many :reads, dependent: :destroy
   validates :genre, presence: true
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :reads, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/reads/create.js.erb
+++ b/app/views/reads/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/read", text: @text) %>'

--- a/app/views/reads/destroy.js.erb
+++ b/app/views/reads/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/unread", text: @text) %>'

--- a/app/views/texts/_read.html.erb
+++ b/app/views/texts/_read.html.erb
@@ -1,2 +1,2 @@
 <%# 「読破済み」(クリックすると読破済み解除) %>
-  <%= link_to "★", text_reads_path(@text), method: :delete %>
+  <%= link_to "★", text_reads_path(text), method: :delete %>

--- a/app/views/texts/_read.html.erb
+++ b/app/views/texts/_read.html.erb
@@ -1,2 +1,1 @@
-<%# 「読破済み」(クリックすると読破済み解除) %>
-  <%= link_to "★", text_reads_path(text), method: :delete %>
+<%= link_to "読破済みを解除", text_reads_path(text), method: :delete, class: "btn btn-primary btn-block" %>

--- a/app/views/texts/_read.html.erb
+++ b/app/views/texts/_read.html.erb
@@ -1,0 +1,2 @@
+<%# 「読破済み」(クリックすると読破済み解除) %>
+  <%= link_to "★", text_reads_path(@text), method: :delete %>

--- a/app/views/texts/_read.html.erb
+++ b/app/views/texts/_read.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みを解除", text_reads_path(text), method: :delete, class: "btn btn-primary btn-block" %>
+<%= link_to "読破済みを解除", text_reads_path(text), method: :delete, remote: true, class: "btn btn-primary btn-block" %>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,2 +1,1 @@
-<%# 「読破済み」にしていない %>
-<%= link_to "☆", text_reads_path(text), method: :post %>
+<%= link_to "読破済みにする", text_reads_path(text), method: :post, class: "btn btn-secondary btn-block" %>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,0 +1,2 @@
+<%# 「読破済み」にしていない %>
+<%= link_to "☆", text_reads_path(@text), method: :post %>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みにする", text_reads_path(text), method: :post, class: "btn btn-secondary btn-block" %>
+<%= link_to "読破済みにする", text_reads_path(text), method: :post, remote: true, class: "btn btn-secondary btn-block" %>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,2 +1,2 @@
 <%# 「読破済み」にしていない %>
-<%= link_to "☆", text_reads_path(@text), method: :post %>
+<%= link_to "☆", text_reads_path(text), method: :post %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -5,7 +5,7 @@
   <div class="row">
     <% @texts.each do |text| %>
       <div class="col-12 col-md-6 col-lg-4 text-card-container">
-        <%= link_to text, class: "card content-card border-dark mb-3 text-decoration-none",target: :_blank, rel: "noopener noreferrer" do %>
+        <%= link_to text, class: "card content-card border-dark mb-3 text-decoration-none", target: :_blank, rel: "noopener noreferrer" do %>
           <div class="card-header p-0">
             <img class="card-img-top" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
           </div>
@@ -17,7 +17,7 @@
                 <%= render "unread", text: text %>
               <% end %>
             </object>
-            <p class="card-text text-title"><%= text.title %></p>
+            <p class="card-text text-title mt-4"><%= text.title %></p>
             <p>【<%= text.genre %>】</p>
           </div>
         <% end %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -5,12 +5,21 @@
   <div class="row">
     <% @texts.each do |text| %>
       <div class="col-12 col-md-6 col-lg-4 text-card-container">
-        <%= link_to text, class: "card content-card border-dark mb-3", target: :_blank, rel: "noopener noreferrer" do %>
+        <%= link_to text, class: "card content-card border-dark mb-3 text-decoration-none",target: :_blank, rel: "noopener noreferrer" do %>
+          <div class="card-header p-0">
             <img class="card-img-top" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
-            <div class="card-body text-dark text-card-body">
-              <p class="card-text text-title"><%= text.title %></p>
-              <p>【<%= text.genre %>】</p>
-            </div>
+          </div>
+          <div class="card-body text-dark text-card-body">
+            <object>
+              <% if @read_text_ids.include?(text.id) %>
+                <%= render "read", text: text %>
+              <% else %>
+                <%= render "unread", text: text %>
+              <% end %>
+            </object>
+            <p class="card-text text-title"><%= text.title %></p>
+            <p>【<%= text.genre %>】</p>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -10,7 +10,7 @@
             <img class="card-img-top" src="https://trello-attachments.s3.amazonaws.com/5e65d7fe7e526f7060e27480/5fbf3f36bf714b2cddb82681/x/3af2293df5cad71e0745f06ed650acb1/no_image.jpg">
           </div>
           <div class="card-body text-dark text-card-body">
-            <object>
+            <object id="text-<%= text.id %>">
               <% if @read_text_ids.include?(text.id) %>
                 <%= render "read", text: text %>
               <% else %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,2 +1,9 @@
 <h1><%= @text.title %></h1>
 <p><%= markdown(@text.content) %></p>
+<p>
+  <% if @text.read_by?(current_user) %>
+    <%= render "read", post: @text %>
+  <% else %>
+    <%= render "unread", post: @text %>
+  <% end %>
+</p>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -2,8 +2,8 @@
 <p><%= markdown(@text.content) %></p>
 <p>
   <% if @text.read_by?(current_user) %>
-    <%= render "read", post: @text %>
+    <%= render "read", text: @text %>
   <% else %>
-    <%= render "unread", post: @text %>
+    <%= render "unread", text: @text %>
   <% end %>
 </p>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @text.title %></h1>
 <p><%= markdown(@text.content) %></p>
-<p>
+<p id="text-<%= @text.id %>">
   <% if @text.read_by?(current_user) %>
     <%= render "read", text: @text %>
   <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root to: 'texts#index'
-  resources :texts ,only: [:index, :show]
+  resources :texts ,only: [:index, :show] do
+    resource :reads, only: [:create, :destroy]
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root to: 'texts#index'
-  resources :texts ,only: [:index, :show] do
+  resources :texts, only: [:index, :show] do
     resource :reads, only: [:create, :destroy]
   end
 end

--- a/db/migrate/20210220102526_create_reads.rb
+++ b/db/migrate/20210220102526_create_reads.rb
@@ -1,0 +1,12 @@
+class CreateReads < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reads do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :reads, [:user_id, :text_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_14_124956) do
+ActiveRecord::Schema.define(version: 2021_02_20_102526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_02_14_124956) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "reads", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_reads_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_reads_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_reads_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.string "genre"
     t.string "title"
@@ -69,4 +79,6 @@ ActiveRecord::Schema.define(version: 2021_02_14_124956) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "reads", "texts"
+  add_foreign_key "reads", "users"
 end


### PR DESCRIPTION
## 24

close #24 

## 実装内容

- Read モデルと reads テーブルを作成し、一意性制約を加えてマイグレーション
  - User モデルと Text モデル関連付け
  - Read モデルにバリデーションを追加
- reads のルーティングと reads コントローラを設定
- Text モデルに読破済み判定メソッドを追加
- 読破済み機能の部分テンプレートを作成
  - 詳細ページに読破済み機能を実装
  -  一覧ページに読破済み機能を実装
-  Bootstrap のボタンスタイルを利用
- 読破済み機能を非同期化

## 参考資料

- 読破済み機能
  - [やんばるCODE教材（モデルの関連付け その2(多対多)）](https://www.yanbaru-code.com/texts/297)
  - [【公式】Bootstrap（Button）](https://getbootstrap.jp/docs/4.5/components/buttons/)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認