### PR TITLE
LINE一覧ページの実装

### DIFF
--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -1,0 +1,9 @@
+class LinesController < ApplicationController
+  def index
+    @lines = Line.all
+  end
+
+  def show
+    @line = Line.find(params[:id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,4 +48,12 @@ module ApplicationHelper
   def max_width
     "mw-xl"
   end
+
+  def bg_color
+    if controller.controller_name == "lines"
+      "bg-success"
+    else
+      "bg-primary"
+    end
+  end
 end

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,0 +1,2 @@
+class Line < ApplicationRecord
+end

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,2 +1,5 @@
 class Line < ApplicationRecord
+  validates :genre, presence: true
+  validates :title, presence: true
+  validates :content, presence: true
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md mw-lg bg-primary navbar-dark header-nav ">
+<nav class="navbar navbar-expand-md mw-lg navbar-dark header-nav">
   <a class="navbar-brand" href="#">やんばるエキスパート</a>
   <button class="navbar-toggler" data-toggle="collapse" data-target="#navbarNav">
     <span class="navbar-toggler-icon"></span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,7 +20,7 @@
           <a class="dropdown-item" href="#">PHP動画教材</a>
         </div>
       </div>
-      <a class="nav-item nav-link" href="#">LINE</a>
+      <%= link_to "LINE", lines_path ,class:"nav-item nav-link" %>
       <%# ログイン時 %>
       <% if user_signed_in? %>
       <div class="nav-item dropdown">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 </head>
 
 <body>
-  <header class="fixed-top bg-primary">
+  <header class="fixed-top <%= bg_color %>">
     <%= render 'layouts/header'%>
   </header>
   <main>

--- a/app/views/lines/index.html.erb
+++ b/app/views/lines/index.html.erb
@@ -1,0 +1,19 @@
+<h1 class="text-center text-success">LINE</h1>
+<table class="table table-striped">
+  <thead class="text-white bg-success">
+    <tr>
+      <th>No.</th>
+      <th>ジャンル</th>
+      <th>内容</th>
+    </tr>
+    <thead>
+    <tbody>
+      <% @lines.each.with_index(1) do |line, i| %>
+      <tr>
+        <th scope="row"><%= i %></th>
+        <td><%= line.genre %></td>
+        <td><%= link_to "#{line.title}", line , target: :_blank , rel: "noopener noreferrer"%></td>
+      </tr>
+      <% end %>
+    </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
     resource :reads, only: [:create, :destroy]
   end
   resources :movies, only: [:index]
+  resources :lines, only: [:index, :show]
 end

--- a/db/migrate/20210302031927_create_lines.rb
+++ b/db/migrate/20210302031927_create_lines.rb
@@ -1,0 +1,11 @@
+class CreateLines < ActiveRecord::Migration[6.1]
+  def change
+    create_table :lines do |t|
+      t.string :genre
+      t.string :title
+      t.string :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_102526) do
+ActiveRecord::Schema.define(version: 2021_03_02_031927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,14 @@ ActiveRecord::Schema.define(version: 2021_02_20_102526) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "lines", force: :cascade do |t|
+    t.string "genre"
+    t.string "title"
+    t.string "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "movies", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,3 +21,6 @@ ImportCsv.text_import("db/csv_data/text_data.csv")
 
 Movie.destroy_all
 ImportCsv.movie_import("db/csv_data/movie_data.csv")
+
+Line.destroy_all
+ImportCsv.line_import("db/csv_data/line_data.csv")

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -27,7 +27,7 @@ class ImportCsv
     CSV.foreach(path, headers: true) do |row|
       Line.create!(
         genre: row["genre"],
-        titile: row["title"],
+        title: row["title"],
         content: row["content"]
       )
     end

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -22,4 +22,15 @@ class ImportCsv
     end
     puts "動画教材のCSVデータ投入に成功しました。"
  end
+
+  def self.import(path)
+    CSV.foreach(path, headers: true) do |row|
+      Line.create!(
+        genre: row["genre"],
+        titile: row["title"],
+        content: row["content"]
+      )
+    end
+    puts "LINE教材のCSVデータ投入に成功しました。"
+  end
 end

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -23,7 +23,7 @@ class ImportCsv
     puts "動画教材のCSVデータ投入に成功しました。"
  end
 
-  def self.import(path)
+  def self.line_import(path)
     CSV.foreach(path, headers: true) do |row|
       Line.create!(
         genre: row["genre"],


### PR DESCRIPTION
close ##52

## 実装内容

- モデルの作成
  - バリデーション設定
- コントローラーの作成
- ルーティング設定
- ナビバーに「LINE」のリンク追加
  - コントローラーで分岐してヘッダーの背景色をLINE画面にいるのみ緑色に変更
- LINE教材の一覧表示をするviewページ作成
- CSVインポート処理
  - lib/autoloads/import.csv.rbにてインポート処理の実行コードを記述
  - db/seeds.rb に（db/csv_data/line_data.csv）を読み込み lines テーブルにデータを投入する処理を追加
  - 先に Line.destroy_all を入れ，実行時にデータを初期化できるようにしておくこと
- rails db:seed を実行し，Railsコンソールなどで初期データが入ることを確認すること

## 参考資料

- コントーラによるヘッダー背景色変更のメソッド作成
  - [Qiita]( https://qiita.com/lasershow/items/e7a75d3e1653c9ca39d8 )<ViewやヘルパーやControllerにおいて、コントローラ名やアクション名で条件分岐する方法>


## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
