### PR TITLE
フッター追加

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,4 @@
+<nav class="navbar navbar-expand-md mw-lg navbar-dark header-nav justify-content-center">
+  <a class="navbar-brand" target="_blank" rel="noopener" href="http://utina.yoshitokamizato.com/">ブログ</a>
+  <a class="navbar-brand" target="_blank" rel="noopener" href="https://www.youtube.com/channel/UCwrDvYey9uKGBeh_l5IF-ag">Youtube</a>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,8 @@
       <%= yield %>
     </div>
   </main>
-  <footer>
+  <footer class="fixed-bottom <%= bg_color %>">
+    <%= render 'layouts/footer'%>
   </footer>
 </body>
 


### PR DESCRIPTION
close #63 

## 実装内容

- Bootstrapのナビバーで実装
  - footerの部分テンプレ作成 
  - LINE一覧画面及びLINE詳細画面の時は、フッターが緑色になるように<%= bg_color %>を指定(実装済のheaderと一緒)
  - navbar-brandクラスが適用されている「ブログ」「youtube」を justify-content-centerより中央揃え
  -  target="_blank" rel="noopener"よりリンク先を別タブで表示

## 参考資料

- navbar-brandクラスが適用されている「ブログ」「youtube」を justify-content-centerより中央揃え
  - ネット記事(https://webnetamemo.com/coding/bootstrap3/201905258315)

-  target="_blank" rel="noopener"よりリンク先を別タブで表示
   -   [Qiita記事](https://qiita.com/Kazuhiro_Mimaki/items/b3f2d718d2bae9083290)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認