### PR TITLE
動画教材の進捗管理をマイページに実装

### DIFF
--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -1,5 +1,6 @@
 class MyPagesController < ApplicationController
   def index
     @text_progress_data = Genre.progress_data(current_user, Text)
+    @movie_progress_data = Genre.progress_data(current_user, Movie)
   end
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -11,19 +11,25 @@ class Genre < ApplicationRecord
     end
   end
 
-  # 進捗管理のデータをビューで取り出しやすいように配列に加工
+  # 進捗管理データをビューで取り出しやすいようにハッシュに加工
   def self.progress_data(user, type)
+    # TextモデルまたはMovieモデルから教材数の配列を呼び出し
     counts = type.total_count
     completed_counts = type.completed_count(user)
+
     genres = Genre.all
     progress_data = {}
 
     genres.each do |genre|
+      # 教材数の配列からジャンル毎にデータを取り出して変数へ代入
       total_count = counts[genre.parameter] || 0
       completed_count = completed_counts[genre.parameter] || 0
+
+      #ビューで表示する「(完了済み教材/教材数)」とパーセンテージを変数へ代入
       count = "#{completed_count}/#{total_count}"
       percentage = self.percentage(completed_count, total_count)
 
+      # ビューで使うデータをハッシュに収納
       progress_data.store(
         genre.parameter,
           {

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -7,4 +7,14 @@ class Movie < ApplicationRecord
   def watched_by?(user)
     watcheds.find_by(user_id: user.id).present?
   end
+
+  # ジャンル別の教材数を配列で取得
+  def self.total_count
+    self.group(:genre).count
+  end
+
+  # 視聴済みの教材数を配列で取得
+  def self.completed_count(user)
+    user.watched_movies.group(:genre).count
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -8,12 +8,12 @@ class Text < ApplicationRecord
     reads.find_by(user_id: user.id).present?
   end
 
-  # ジャンル別のデータ数を配列で取得
+  # ジャンル別の教材数を配列で取得
   def self.total_count
     self.group(:genre).count
   end
 
-  # 読破済みの数を配列で取得
+  # 読破済みの教材数を配列で取得
   def self.completed_count(user)
     user.read_texts.group(:genre).count
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :watcheds, dependent: :destroy
+  has_many :watched_movies, through: :watcheds, source: :movie
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 end

--- a/app/views/my_pages/index.html.erb
+++ b/app/views/my_pages/index.html.erb
@@ -4,4 +4,8 @@
   <% @text_progress_data.each do |key, value| %>
     <%= render "progress", data: value %>
   <% end %>
+  <h2 class="watched-movie mb-4">動画教材 視聴済み</h2>
+  <% @movie_progress_data.each do |key, value| %>
+    <%= render "progress", data: value %>
+  <% end %>
 </div>

--- a/app/views/my_pages/index.html.erb
+++ b/app/views/my_pages/index.html.erb
@@ -1,11 +1,15 @@
 <div class="check-progress">
   <h1 class="text-center mb-5">進捗管理</h1>
-  <h2 class="read-texts mb-4">テキスト教材 読破済み</h2>
-  <% @text_progress_data.each do |key, value| %>
-    <%= render "progress", data: value %>
-  <% end %>
-  <h2 class="watched-movie mb-4">動画教材 視聴済み</h2>
-  <% @movie_progress_data.each do |key, value| %>
-    <%= render "progress", data: value %>
-  <% end %>
+  <div class="ead-texts mb-5">
+    <h2 class="mb-3">テキスト教材 読破済み</h2>
+    <% @text_progress_data.each do |key, value| %>
+      <%= render "progress", data: value %>
+    <% end %>
+  </div>
+  <div class="watched-movies mb-5">
+    <h2 class="mb-3">動画教材 視聴済み</h2>
+    <% @movie_progress_data.each do |key, value| %>
+      <%= render "progress", data: value %>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
## 68

close #68

## 実装内容
- User モデルと Movie モデル、Watched モデルを関連付け
- Watched モデル、Genre モデルにデータを取得するメソッドを追加
- Genre モデルのメソッドにコメントを追加
- my_pages コントローラで動画視聴済みデータを呼び出しビューへ受け渡す記述を追加
- my_pages の indexビューに動画教材 視聴済みの表示を追加

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
