### PR TITLE
各教材ページのタイトルを genresテーブル参照に変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,11 +61,12 @@ module ApplicationHelper
     end
   end
 
-  def title_name
+  def text_title
     if params[:genre] == nil
       "Ruby/Rails テキスト教材"
     else
-      "PHP テキスト教材"
+      genre = Genre.find_by(parameter: params[:genre])
+      "#{genre.title} テキスト教材"
     end
   end
 
@@ -73,7 +74,8 @@ module ApplicationHelper
     if params[:genre] == nil
       "Ruby/Rails 動画教材"
     else
-      "PHP 動画教材"
+      genre = Genre.find_by(parameter: params[:genre])
+      "#{genre.title} 動画教材"
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,21 +61,12 @@ module ApplicationHelper
     end
   end
 
-  def text_title
+  def genre_title
     if params[:genre] == nil
-      "Ruby/Rails テキスト教材"
+      "Ruby/Rails"
     else
       genre = Genre.find_by(parameter: params[:genre])
-      "#{genre.title} テキスト教材"
-    end
-  end
-
-  def movie_title
-    if params[:genre] == nil
-      "Ruby/Rails 動画教材"
-    else
-      genre = Genre.find_by(parameter: params[:genre])
-      "#{genre.title} 動画教材"
+      genre.title
     end
   end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,5 +1,5 @@
 <div class="contents-title text-center">
-  <h2><%= movie_title %></h2>
+  <h2><%= "#{genre_title} 動画教材" %></h2>
 </div>
 <div class="container mt-5">
   <div class="row">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,6 +1,6 @@
 <div class="texts-wrapper">
   <div class="contents-title text-center">
-    <h1><%= text_title %></h1>
+    <h1><%= "#{genre_title} テキスト教材" %></h1>
   </div>
   <% if current_user.nil? %>
     <div class="info_box">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,6 +1,6 @@
 <div class="texts-wrapper">
   <div class="contents-title text-center">
-    <h1><%= title_name %></h1>
+    <h1><%= text_title %></h1>
   </div>
   <% if current_user.nil? %>
     <div class="info_box">


### PR DESCRIPTION
## 85
close #85 

## 実装内容
- 各教材ページのタイトルを genres モデルより取得するように変更

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認