### PR TITLE
factory_bot の記述をテスト・開発環境のファイルに移動

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,5 @@ module TeamProject
 
     # Don't generate system test files.
     config.generators.system_tests = nil
-    config.factory_bot.definition_file_paths = ["spec/factories"]
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.factory_bot.definition_file_paths = ["spec/factories"]
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.factory_bot.definition_file_paths = ["spec/factories"]
 end


### PR DESCRIPTION
## 89
close #89 

## 実装内容
- factory_bot のパス指定の記述を `config/application.rb` から `config/environments/development.rb` と `config/environments/test.rb` に移動

## 参考資料
- factory_bot_rails の導入
  - [やんばるCODEアプリ（RSpec（factory_bot_railsの基礎））](https://www.yanbaru-code.com/texts/299)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認