### PR TITLE
ヘッダーからAWS教材へのリンクを削除

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,7 +10,6 @@
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
           <%= link_to "Ruby/Railsテキスト教材", texts_path, class: "dropdown-item" %>
           <%= link_to "Ruby/Rails動画教材", movies_path, class: "dropdown-item" %>
-          <a class="dropdown-item" href="#">AWS講座</a>
         </div>
       </div>
       <div class="nav-item dropdown">


### PR DESCRIPTION
## 91
close #91

## 実装内容
- ヘッダーからAWS教材へのリンクを削除

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認